### PR TITLE
Show timings in milliseconds

### DIFF
--- a/template_timings_panel/panels/TemplateTimings.py
+++ b/template_timings_panel/panels/TemplateTimings.py
@@ -21,7 +21,7 @@ def _template_render_wrapper(func, key, should_add=lambda n: True, name=lambda s
 
         start_time = time.time()
         result = func(self, *args, **kwargs)
-        time_taken = time.time() - start_time
+        time_taken = int(round((time.time() - start_time) * 1000))
 
         if should_add(name(self)):
             results.timings[key][name(self)] = time_taken

--- a/template_timings_panel/templates/debug_toolbar_template_timings.html
+++ b/template_timings_panel/templates/debug_toolbar_template_timings.html
@@ -31,7 +31,7 @@
     {% for name, time in template_timings.blocks.items %}
     <tr class="{% cycle 'djDebugOdd' 'djDebugEven' %}">
         <td>{{ name }}</td>
-        <td>{{ time }}</td>
+        <td>{{ time }} ms</td>
     </tr>
     {% endfor %}
     </tbody>


### PR DESCRIPTION
It makes more sense to show the timings in milliseconds than in seconds.
Examples (taken from the images in the README):
- 0.00200009346008 -> 2 ms.
- 0.0 -> 0 ms.
- 0.000999927520752 -> 1 ms.

Timings won't matter if they're below 1 ms anyway. If you still want to keep them you might want to make them clearer.
