### PR TITLE
Optional config to disable console output

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,16 @@ Template-timings is a panel for [Django-debug-toolbar](https://github.com/django
 Django doesn't give you much insight as to why a template might take a long time to render. A block inside a template I was using added significant overhead in a non-obvious way, and I wished I had something like this to show exactly where the bottlekneck was.
 
 ### Install instructions
-Install via pip (pip install django-debug-toolbar-template-timings). Then add __'template_timings_panel.panels.TemplateTimings.TemplateTimings'__ to your DEBUG_TOOLBAR_PANELS, and also add __'template_timings_panel'__ to your INSTALLED_APPS
+Install via pip (pip install django-debug-toolbar-template-timings). Then add __'template_timings_panel.panels.TemplateTimings.TemplateTimings'__ to your DEBUG_TOOLBAR_PANELS, and also add __'template_timings_panel'__ to your INSTALLED_APPS.
+
+### Configuration
+Configuration is optional.
+
+To suppress output to the console add the following to your ``settings``:
+
+    TEMPLATE_TIMINGS_SETTINGS = {
+        'PRINT_TIMINGS': False,
+    }
 
 ### Preview
 ![](http://i.imgur.com/RyErSQn.png)


### PR DESCRIPTION
Hello

I found that having the timings printed to the console when using `runserver` could sometimes be distracting.

I've added an optional config that allows this to be disabled (it's on by default though).

Ben.
