### PR TITLE
Avoid KeyErrors in timing results

### DIFF
--- a/template_timings_panel/panels/TemplateTimings.py
+++ b/template_timings_panel/panels/TemplateTimings.py
@@ -76,7 +76,7 @@ def _template_render_wrapper(func, key, should_add=lambda n: True, name=lambda s
         name_self = name(self)
 
         if name_self not in results.timings[key] and should_add(name_self):
-            results.timings[key][name_self] = {
+            results.timings.setdefault(key, {})[name_self] = {
                 'count': 0,
                 'min': None,
                 'max': None,


### PR DESCRIPTION
For some weird reason I get `KeyError`s in this part…

I'm not exactly sure why they happen, because as far as I understand it they should not.  
Sadly I'm under a time constraint right now, so I had to "workaround" this, rather than truly fix it. Below is the workaround, which uses the wonderful `setdefault`
