### PR TITLE
Update TemplateTimings.py

### DIFF
--- a/template_timings_panel/panels/TemplateTimings.py
+++ b/template_timings_panel/panels/TemplateTimings.py
@@ -1,7 +1,7 @@
 from debug_toolbar.panels import Panel
 from django.conf import settings
 from django.template import base as template_base
-from django.template.base import Template, Library
+from django.template import Template, Library
 from django.template.loader_tags import BlockNode
 from debug_toolbar.panels import sql
 from django.core.exceptions import ImproperlyConfigured


### PR DESCRIPTION
Hi! 

I am trying work under django 1.9 

```
from django.template import base as template_base

def _tag_compiler(func):

    @functools.wraps(func)
    def wrapper(*args, **kwargs):
        if 'node_class' in kwargs:
            wrap_generic_node(kwargs['node_class'], kwargs['name'])
            FOUND_GENERIC_NODES.add((kwargs['node_class'], kwargs['name']))
        return func(*args, **kwargs)

    return wrapper

template_base.generic_tag_compiler = _tag_compiler(
    template_base.generic_tag_compiler)
```
Do u even use this code?