### PR TITLE
Mention django 1.9 incompatibility and replace pypi shield

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,12 +2,13 @@
 Template-Timings
 ================
 
-.. image:: https://pypip.in/d/django-debug-toolbar-template-timings/badge.png
+.. image:: https://img.shields.io/pypi/v/django-debug-toolbar-template-timings.svg
     :target: https://pypi.python.org/pypi/django-debug-toolbar-template-timings
 
 
 Template-timings is a panel for Django Debug Toolbar that gives an in-dept breakdown of the time it takes to render your Django templates (including templates included via {% extends %} and {% include %}).
 
+Template-timings supports Django 1.8 and below, Django 1.9 and above do not work at the moment.
 
 Install
 =======


### PR DESCRIPTION
because i needed a while until i realized that template-timings wouldn't work for me and i'd like to spare others the wasted time.

edit: rendered readme [here](https://github.com/karyon/django-debug-toolbar-template-timings)