### PR TITLE
Adding compatibility for django 1.9

### DIFF
--- a/template_timings_panel/panels/TemplateTimings.py
+++ b/template_timings_panel/panels/TemplateTimings.py
@@ -1,6 +1,5 @@
 from debug_toolbar.panels import Panel
 from django.conf import settings
-from django.template import base as template_base
 from django.template import Template, Library
 from django.template.loader_tags import BlockNode
 from debug_toolbar.panels import sql
@@ -87,8 +86,7 @@ def wrap_generic_node(node, name):
             node.render = _template_render_wrapper(
                 node.render, node.__name__, name=lambda unused_: name)
 
-template_base.generic_tag_compiler = _tag_compiler(
-    template_base.generic_tag_compiler)
+Library.simple_tag = _tag_compiler(Library.simple_tag)
 
 
 def _template_render_wrapper(func, key, should_add=lambda n: True, name=lambda s: s.name if s.name else ''):

--- a/template_timings_panel/panels/TemplateTimings.py
+++ b/template_timings_panel/panels/TemplateTimings.py
@@ -1,5 +1,6 @@
 from debug_toolbar.panels import Panel
 from django.conf import settings
+from django.template import base as template_base
 from django.template import Template, Library
 from django.template.loader_tags import BlockNode
 from debug_toolbar.panels import sql
@@ -86,7 +87,10 @@ def wrap_generic_node(node, name):
             node.render = _template_render_wrapper(
                 node.render, node.__name__, name=lambda unused_: name)
 
-Library.simple_tag = _tag_compiler(Library.simple_tag)
+try:
+    template_base.generic_tag_compiler = _tag_compiler(template_base.generic_tag_compiler)
+except:
+    Library.simple_tag = _tag_compiler(Library.simple_tag)
 
 
 def _template_render_wrapper(func, key, should_add=lambda n: True, name=lambda s: s.name if s.name else ''):


### PR DESCRIPTION
Hi,

I changed the generic_tag_compiler to the simple_tag as @AgustinLado said in https://github.com/orf/django-debug-toolbar-template-timings/issues/24

i tried to keep the compatibility for django 1.8 but that's the first time I do that and I could not test it yet.

Except that, it works pretty well in django 1.9 with this modification.