### PR TITLE
Ensure default _get_timings() provides a dict instead of None

### DIFF
--- a/template_timings_panel/panels/TemplateTimings.py
+++ b/template_timings_panel/panels/TemplateTimings.py
@@ -175,7 +175,7 @@ class TemplateTimings(Panel):
     has_content = True
 
     def _get_timings(self):
-        return getattr(results, "timings", None)
+        return getattr(results, "timings", {})
 
     def _results_to_list(self, results):
         returner = {}


### PR DESCRIPTION
This fixes `'NoneType' object is not iterable` which can happen if you return HTML directly without building a template.